### PR TITLE
convert color attributes to properties

### DIFF
--- a/examples/color/color.py
+++ b/examples/color/color.py
@@ -3,34 +3,34 @@ from generativepy.color import Color
 
 
 def draw(ctx, width, height, frame_no, frame_count):
-    ctx.set_source_rgba(*Color(1).get_rgba())
+    ctx.set_source_rgba(*Color(1).rgba)
     ctx.paint()
 
-    ctx.set_source_rgba(*Color(0.5, 0, 0).get_rgba())
+    ctx.set_source_rgba(*Color(0.5, 0, 0).rgba)
     ctx.rectangle(50, 50, 100, 100)
     ctx.fill()
 
-    ctx.set_source_rgba(*Color(0, 0, 0.5).get_rgba())
+    ctx.set_source_rgba(*Color(0, 0, 0.5).rgba)
     ctx.rectangle(200, 50, 100, 100)
     ctx.fill()
 
-    ctx.set_source_rgba(*Color(0.8, 0.8, 0).get_rgba())
+    ctx.set_source_rgba(*Color(0.8, 0.8, 0).rgba)
     ctx.rectangle(350, 50, 100, 100)
     ctx.fill()
 
-    ctx.set_source_rgba(*Color(0.5).get_rgba())
+    ctx.set_source_rgba(*Color(0.5).rgba)
     ctx.rectangle(50, 200, 100, 100)
     ctx.fill()
 
-    ctx.set_source_rgba(*Color(0.25).get_rgba())
+    ctx.set_source_rgba(*Color(0.25).rgba)
     ctx.rectangle(200, 200, 100, 100)
     ctx.fill()
 
-    ctx.set_source_rgb(*Color(0.8, 0.8, 0).get_rgb())
+    ctx.set_source_rgb(*Color(0.8, 0.8, 0).rgb)
     ctx.rectangle(330, 180, 100, 100)
     ctx.fill()
 
-    ctx.set_source_rgba(*Color(1, 0, 1, 0.5).get_rgba())
+    ctx.set_source_rgba(*Color(1, 0, 1, 0.5).rgba)
     ctx.rectangle(370, 220, 100, 100)
     ctx.fill()
 

--- a/examples/color/csscolor.py
+++ b/examples/color/csscolor.py
@@ -3,34 +3,34 @@ from generativepy.color import Color
 
 
 def draw(ctx, width, height, frame_no, frame_count):
-    ctx.set_source_rgba(*Color(1).get_rgba())
+    ctx.set_source_rgba(*Color(1).rgba)
     ctx.paint()
 
-    ctx.set_source_rgba(*Color('salmon').get_rgba())
+    ctx.set_source_rgba(*Color('salmon').rgba)
     ctx.rectangle(50, 50, 100, 100)
     ctx.fill()
 
-    ctx.set_source_rgba(*Color('firebrick').get_rgba())
+    ctx.set_source_rgba(*Color('firebrick').rgba)
     ctx.rectangle(200, 50, 100, 100)
     ctx.fill()
 
-    ctx.set_source_rgba(*Color('fuchsia').get_rgba())
+    ctx.set_source_rgba(*Color('fuchsia').rgba)
     ctx.rectangle(350, 50, 100, 100)
     ctx.fill()
 
-    ctx.set_source_rgba(*Color('deepskyblue').get_rgba())
+    ctx.set_source_rgba(*Color('deepskyblue').rgba)
     ctx.rectangle(50, 200, 100, 100)
     ctx.fill()
 
-    ctx.set_source_rgba(*Color('hotpink').get_rgba())
+    ctx.set_source_rgba(*Color('hotpink').rgba)
     ctx.rectangle(200, 200, 100, 100)
     ctx.fill()
 
-    ctx.set_source_rgb(*Color('lawngreen').get_rgb())
+    ctx.set_source_rgb(*Color('lawngreen').rgb)
     ctx.rectangle(330, 180, 100, 100)
     ctx.fill()
 
-    ctx.set_source_rgba(*Color('navy', 0.5).get_rgba())
+    ctx.set_source_rgba(*Color('navy', 0.5).rgba)
     ctx.rectangle(370, 220, 100, 100)
     ctx.fill()
 

--- a/examples/color/hslbars.py
+++ b/examples/color/hslbars.py
@@ -4,21 +4,21 @@ from generativepy.color import Color
 
 
 def draw(ctx, width, height, frame_no, frame_count):
-    ctx.set_source_rgba(*Color(1).get_rgba())
+    ctx.set_source_rgba(*Color(1).rgba)
     ctx.paint()
 
     for i in range(200):
-        ctx.set_source_rgba(*Color.of_hsl(i / 200, 1, 0.5).get_rgba())
+        ctx.set_source_rgba(*Color.of_hsl(i / 200, 1, 0.5).rgba)
         ctx.rectangle(i + 50, 50, 1, 50)
         ctx.fill()
 
     for i in range(200):
-        ctx.set_source_rgba(*Color.of_hsl(0.25, i/200, 0.5).get_rgba())
+        ctx.set_source_rgba(*Color.of_hsl(0.25, i/200, 0.5).rgba)
         ctx.rectangle(i + 50, 150, 1, 50)
         ctx.fill()
 
     for i in range(200):
-        ctx.set_source_rgba(*Color.of_hsl(0.25, 1, i/200).get_rgba())
+        ctx.set_source_rgba(*Color.of_hsl(0.25, 1, i/200).rgba)
         ctx.rectangle(i + 50, 250, 1, 50)
         ctx.fill()
 

--- a/examples/color/hslcolor.py
+++ b/examples/color/hslcolor.py
@@ -3,34 +3,34 @@ from generativepy.color import Color
 
 
 def draw(ctx, width, height, frame_no, frame_count):
-    ctx.set_source_rgba(*Color(1).get_rgba())
+    ctx.set_source_rgba(*Color(1).rgba)
     ctx.paint()
 
-    ctx.set_source_rgba(*Color.of_hsl(0, 0.5, 0.5).get_rgba())
+    ctx.set_source_rgba(*Color.of_hsl(0, 0.5, 0.5).rgba)
     ctx.rectangle(50, 50, 100, 100)
     ctx.fill()
 
-    ctx.set_source_rgba(*Color.of_hsl(0.33, 0.5, 0.5).get_rgba())
+    ctx.set_source_rgba(*Color.of_hsl(0.33, 0.5, 0.5).rgba)
     ctx.rectangle(200, 50, 100, 100)
     ctx.fill()
 
-    ctx.set_source_rgba(*Color.of_hsl(0.66, 0.5, 0.5).get_rgba())
+    ctx.set_source_rgba(*Color.of_hsl(0.66, 0.5, 0.5).rgba)
     ctx.rectangle(350, 50, 100, 100)
     ctx.fill()
 
-    ctx.set_source_rgba(*Color.of_hsl(0, 0.25, 0.5).get_rgba())
+    ctx.set_source_rgba(*Color.of_hsl(0, 0.25, 0.5).rgba)
     ctx.rectangle(50, 200, 100, 100)
     ctx.fill()
 
-    ctx.set_source_rgba(*Color.of_hsl(0, 0.5, 0.25).get_rgba())
+    ctx.set_source_rgba(*Color.of_hsl(0, 0.5, 0.25).rgba)
     ctx.rectangle(200, 200, 100, 100)
     ctx.fill()
 
-    ctx.set_source_rgba(*Color.of_hsl(0, 0.5, 0.5).get_rgba())
+    ctx.set_source_rgba(*Color.of_hsl(0, 0.5, 0.5).rgba)
     ctx.rectangle(330, 180, 100, 100)
     ctx.fill()
 
-    ctx.set_source_rgba(*Color.of_hsla(0.5, 0.5, 0.5, 0.5).get_rgba())
+    ctx.set_source_rgba(*Color.of_hsla(0.5, 0.5, 0.5, 0.5).rgba)
     ctx.rectangle(370, 220, 100, 100)
     ctx.fill()
 

--- a/examples/color/rgbcolor.py
+++ b/examples/color/rgbcolor.py
@@ -3,24 +3,24 @@ from generativepy.color import Color
 
 
 def draw(ctx, width, height, frame_no, frame_count):
-    ctx.set_source_rgba(*Color(1).get_rgba())
+    ctx.set_source_rgba(*Color(1).rgba)
     ctx.paint()
 
     for i in range(200):
         for j in range(200):
-            ctx.set_source_rgba(*Color(i/200, j/200, 0).get_rgba())
+            ctx.set_source_rgba(*Color(i/200, j/200, 0).rgba)
             ctx.rectangle(i + 50, j + 50, 1, 1)
             ctx.fill()
 
     for i in range(200):
         for j in range(200):
-            ctx.set_source_rgba(*Color(i/200, 0, j/200).get_rgba())
+            ctx.set_source_rgba(*Color(i/200, 0, j/200).rgba)
             ctx.rectangle(i + 50, j + 300, 1, 1)
             ctx.fill()
 
     for i in range(200):
         for j in range(200):
-            ctx.set_source_rgba(*Color(0, i/200, j/200).get_rgba())
+            ctx.set_source_rgba(*Color(0, i/200, j/200).rgba)
             ctx.rectangle(i + 50, j + 550, 1, 1)
             ctx.fill()
 

--- a/examples/movie/simplemovie.py
+++ b/examples/movie/simplemovie.py
@@ -3,10 +3,10 @@ from generativepy.color import Color
 
 
 def draw(ctx, width, height, frame_no, frame_count):
-    ctx.set_source_rgba(*Color(1).get_rgba())
+    ctx.set_source_rgba(*Color(1).rgba)
     ctx.paint()
 
-    ctx.set_source_rgba(*Color(0.5, 0, 0).get_rgba())
+    ctx.set_source_rgba(*Color(0.5, 0, 0).rgba)
     ctx.rectangle(50+20*frame_no, 50+10*frame_no, 100, 100)
     ctx.fill()
 

--- a/generativepy/color.py
+++ b/generativepy/color.py
@@ -235,13 +235,16 @@ class Color():
         r, g, b = colorsys.hls_to_rgb(h, l, s)
         return Color(r, g, b, a)
 
-    def get_rgb(self):
+    @property
+    def rgb(self):
         return tuple(self.color[:3])
 
-    def get_rgba(self):
+    @property
+    def rgba(self):
         return self.color
 
-    def get_r(self):
+    @property
+    def r(self):
         return self.color[0]
 
     def with_r(self, newval):
@@ -251,7 +254,8 @@ class Color():
     def with_r_factor(self, factor):
         return Color(self.color[0]*factor, self.color[1], self.color[2], self.color[3])
 
-    def get_g(self):
+    @property
+    def g(self):
         return self.color[1]
 
     def with_g(self, newval):
@@ -261,6 +265,7 @@ class Color():
     def with_g_factor(self, factor):
         return Color(self.color[0], self.color[1]*factor, self.color[2], self.color[3])
 
+    @property
     def get_b(self):
         return self.color[2]
 
@@ -271,6 +276,7 @@ class Color():
     def with_b_factor(self, factor):
         return Color(self.color[0], self.color[1], self.color[2]*factor, self.color[3])
 
+    @property
     def get_a(self):
         return self.color[3]
 
@@ -281,7 +287,8 @@ class Color():
     def with_a_factor(self, factor):
         return Color(self.color[0], self.color[1], self.color[2], self.color[3]*factor)
 
-    def get_h(self):
+    @property
+    def h(self):
         h, l, s = colorsys.rgb_to_hls(self.color[0], self.color[1], self.color[2])
         return h
 
@@ -296,7 +303,8 @@ class Color():
         r, g, b = colorsys.hls_to_rgb(Color.clamp(h*factor), l, s)
         return Color(r, g, b, self.color[3])
 
-    def get_s(self):
+    @property
+    def s(self):
         h, l, s = colorsys.rgb_to_hls(self.color[0], self.color[1], self.color[2])
         return s
 
@@ -311,7 +319,8 @@ class Color():
         r, g, b = colorsys.hls_to_rgb(h, l, Color.clamp(s*factor))
         return Color(r, g, b, self.color[3])
 
-    def get_l(self):
+    @property
+    def l(self):
         h, l, s = colorsys.rgb_to_hls(self.color[0], self.color[1], self.color[2])
         return l
 
@@ -328,8 +337,8 @@ class Color():
 
     def lerp(self, other, ratio):
         ratio = Color.clamp(ratio)
-        col1 = self.get_rgba()
-        col2 = other.get_rgba()
+        col1 = self.rgba
+        col2 = other.rgba
         col = [x*(1-ratio) + y*ratio for x, y in zip(col1, col2)]
         return Color(*col)
 

--- a/test/test_color.py
+++ b/test/test_color.py
@@ -7,201 +7,201 @@ class TestColour(unittest.TestCase):
     # Test RGB and RGBA colours
     def test_rgb_rgb_black(self):
         color = Color(0, 0, 0)
-        self.assertEqual(color.get_rgb(), (0, 0, 0))
+        self.assertEqual(color.rgb, (0, 0, 0))
 
     def test_rgb_rgb_color(self):
         color = Color(1, 0.5, 0.25)
-        self.assertEqual(color.get_rgb(), (1, 0.5, 0.25))
+        self.assertEqual(color.rgb, (1, 0.5, 0.25))
 
     def test_rgb_rgba_black(self):
         color = Color(0, 0, 0)
-        self.assertEqual(color.get_rgba(), (0, 0, 0, 1))
+        self.assertEqual(color.rgba, (0, 0, 0, 1))
 
     def test_rgb_rgba_color(self):
         color = Color(1, 0.5, 0.25)
-        self.assertEqual(color.get_rgba(), (1, 0.5, 0.25, 1))
+        self.assertEqual(color.rgba, (1, 0.5, 0.25, 1))
 
     def test_rgba_rgba_transparent(self):
         color = Color(0, 0, 0, 0)
-        self.assertEqual(color.get_rgba(), (0, 0, 0, 0))
+        self.assertEqual(color.rgba, (0, 0, 0, 0))
 
     def test_rgba_rgba_semi(self):
         color = Color(1, 0.5, 0.25, 0.4)
-        self.assertEqual(color.get_rgba(), (1, 0.5, 0.25, 0.4))
+        self.assertEqual(color.rgba, (1, 0.5, 0.25, 0.4))
 
     def test_grey_rgb_black(self):
         color = Color(0)
-        self.assertEqual(color.get_rgb(), (0, 0, 0))
+        self.assertEqual(color.rgb, (0, 0, 0))
 
     # Test grey and grey+alpha modes
     def test_grey_rgb_color(self):
         color = Color(0.25)
-        self.assertEqual(color.get_rgb(), (0.25, 0.25, 0.25))
+        self.assertEqual(color.rgb, (0.25, 0.25, 0.25))
 
     def test_grey_rgba_black(self):
         color = Color(0)
-        self.assertEqual(color.get_rgba(), (0, 0, 0, 1))
+        self.assertEqual(color.rgba, (0, 0, 0, 1))
 
     def test_grey_rgba_color(self):
         color = Color(0.25)
-        self.assertEqual(color.get_rgba(), (0.25, 0.25, 0.25, 1))
+        self.assertEqual(color.rgba, (0.25, 0.25, 0.25, 1))
 
     def test_greya_rgba_transparent(self):
         color = Color(0, 0)
-        self.assertEqual(color.get_rgba(), (0, 0, 0, 0))
+        self.assertEqual(color.rgba, (0, 0, 0, 0))
 
     def test_greya_rgba_semi(self):
         color = Color(0.25, 0.4)
-        self.assertEqual(color.get_rgba(), (0.25, 0.25, 0.25, 0.4))
+        self.assertEqual(color.rgba, (0.25, 0.25, 0.25, 0.4))
 
     # Test CSS and CSS plus alpha modes
     def test_css_rgb(self):
         color = Color('salmon')
-        self.assertAlmostEqual(color.get_rgb()[0], 0.98039215)
-        self.assertAlmostEqual(color.get_rgb()[1], 0.50196078)
-        self.assertAlmostEqual(color.get_rgb()[2], 0.44705882)
+        self.assertAlmostEqual(color.rgb[0], 0.98039215)
+        self.assertAlmostEqual(color.rgb[1], 0.50196078)
+        self.assertAlmostEqual(color.rgb[2], 0.44705882)
 
     def test_css_rgba(self):
         color = Color('salmon')
-        self.assertAlmostEqual(color.get_rgba()[0], 0.98039215)
-        self.assertAlmostEqual(color.get_rgba()[1], 0.50196078)
-        self.assertAlmostEqual(color.get_rgba()[2], 0.44705882)
-        self.assertAlmostEqual(color.get_rgba()[3], 1)
+        self.assertAlmostEqual(color.rgba[0], 0.98039215)
+        self.assertAlmostEqual(color.rgba[1], 0.50196078)
+        self.assertAlmostEqual(color.rgba[2], 0.44705882)
+        self.assertAlmostEqual(color.rgba[3], 1)
 
     def test_cssa_rgba_transparent(self):
         color = Color('salmon', 0)
-        self.assertAlmostEqual(color.get_rgba()[0], 0.98039215)
-        self.assertAlmostEqual(color.get_rgba()[1], 0.50196078)
-        self.assertAlmostEqual(color.get_rgba()[2], 0.44705882)
-        self.assertAlmostEqual(color.get_rgba()[3], 0)
+        self.assertAlmostEqual(color.rgba[0], 0.98039215)
+        self.assertAlmostEqual(color.rgba[1], 0.50196078)
+        self.assertAlmostEqual(color.rgba[2], 0.44705882)
+        self.assertAlmostEqual(color.rgba[3], 0)
 
     def test_cssa_rgba_semi(self):
         color = Color('salmon', 0.7)
-        self.assertAlmostEqual(color.get_rgba()[0], 0.98039215)
-        self.assertAlmostEqual(color.get_rgba()[1], 0.50196078)
-        self.assertAlmostEqual(color.get_rgba()[2], 0.44705882)
-        self.assertAlmostEqual(color.get_rgba()[3], 0.7)
+        self.assertAlmostEqual(color.rgba[0], 0.98039215)
+        self.assertAlmostEqual(color.rgba[1], 0.50196078)
+        self.assertAlmostEqual(color.rgba[2], 0.44705882)
+        self.assertAlmostEqual(color.rgba[3], 0.7)
 
     # Test getters
     def test_get_r(self):
-        val = Color(0.1, 0.2, 0.3, 0.4).get_r()
+        val = Color(0.1, 0.2, 0.3, 0.4).r
         self.assertEqual(val, 0.1)
 
     def test_get_g(self):
-        val = Color(0.1, 0.2, 0.3, 0.4).get_g()
+        val = Color(0.1, 0.2, 0.3, 0.4).g
         self.assertEqual(val, 0.2)
 
     def test_get_b(self):
-        val = Color(0.1, 0.2, 0.3, 0.4).get_b()
+        val = Color(0.1, 0.2, 0.3, 0.4).get_b
         self.assertEqual(val, 0.3)
 
     def test_get_a(self):
-        val = Color(0.1, 0.2, 0.3, 0.4).get_a()
+        val = Color(0.1, 0.2, 0.3, 0.4).get_a
         self.assertEqual(val, 0.4)
 
     def test_get_h(self):
-        val = Color(0.1, 0.2, 0.3, 0.4).get_h()
+        val = Color(0.1, 0.2, 0.3, 0.4).h
         self.assertAlmostEqual(val, 0.58333333)
 
     def test_get_s(self):
-        val = Color(0.1, 0.2, 0.3, 0.4).get_s()
+        val = Color(0.1, 0.2, 0.3, 0.4).s
         self.assertAlmostEqual(val, 0.5)
 
     def test_get_l(self):
-        val = Color(0.1, 0.2, 0.3, 0.4).get_l()
+        val = Color(0.1, 0.2, 0.3, 0.4).l
         self.assertAlmostEqual(val, 0.2)
 
     # Test setters
     def test_with_r(self):
         color = Color(0.1, 0.2, 0.3, 0.4).with_r(0.5)
-        self.assertEqual(color.get_rgba(), (0.5, 0.2, 0.3, 0.4))
+        self.assertEqual(color.rgba, (0.5, 0.2, 0.3, 0.4))
 
     def test_with_g(self):
         color = Color(0.1, 0.2, 0.3, 0.4).with_g(0.5)
-        self.assertEqual(color.get_rgba(), (0.1, 0.5, 0.3, 0.4))
+        self.assertEqual(color.rgba, (0.1, 0.5, 0.3, 0.4))
 
     def test_with_b(self):
         color = Color(0.1, 0.2, 0.3, 0.4).with_b(0.5)
-        self.assertEqual(color.get_rgba(), (0.1, 0.2, 0.5, 0.4))
+        self.assertEqual(color.rgba, (0.1, 0.2, 0.5, 0.4))
 
     def test_with_a(self):
         color = Color(0.1, 0.2, 0.3, 0.4).with_a(0.5)
-        self.assertEqual(color.get_rgba(), (0.1, 0.2, 0.3, 0.5))
+        self.assertEqual(color.rgba, (0.1, 0.2, 0.3, 0.5))
 
     def test_with_h(self):
         color = Color(0.1, 0.2, 0.3, 0.4).with_h(0.5)
-        self.assertAlmostEqual(color.get_rgba()[0], 0.1)
-        self.assertAlmostEqual(color.get_rgba()[1], 0.3)
-        self.assertAlmostEqual(color.get_rgba()[2], 0.3)
-        self.assertAlmostEqual(color.get_rgba()[3], 0.4)
+        self.assertAlmostEqual(color.rgba[0], 0.1)
+        self.assertAlmostEqual(color.rgba[1], 0.3)
+        self.assertAlmostEqual(color.rgba[2], 0.3)
+        self.assertAlmostEqual(color.rgba[3], 0.4)
 
     def test_with_s(self):
         color = Color(0.1, 0.2, 0.3, 0.4).with_s(0.5)
-        self.assertAlmostEqual(color.get_rgba()[0], 0.1)
-        self.assertAlmostEqual(color.get_rgba()[1], 0.2)
-        self.assertAlmostEqual(color.get_rgba()[2], 0.3)
-        self.assertAlmostEqual(color.get_rgba()[3], 0.4)
+        self.assertAlmostEqual(color.rgba[0], 0.1)
+        self.assertAlmostEqual(color.rgba[1], 0.2)
+        self.assertAlmostEqual(color.rgba[2], 0.3)
+        self.assertAlmostEqual(color.rgba[3], 0.4)
 
     def test_with_l(self):
         color = Color(0.1, 0.2, 0.3, 0.4).with_l(0.5)
-        self.assertAlmostEqual(color.get_rgba()[0], 0.25)
-        self.assertAlmostEqual(color.get_rgba()[1], 0.5)
-        self.assertAlmostEqual(color.get_rgba()[2], 0.75)
-        self.assertAlmostEqual(color.get_rgba()[3], 0.4)
+        self.assertAlmostEqual(color.rgba[0], 0.25)
+        self.assertAlmostEqual(color.rgba[1], 0.5)
+        self.assertAlmostEqual(color.rgba[2], 0.75)
+        self.assertAlmostEqual(color.rgba[3], 0.4)
 
     # Test set factors
     def test_with_r_factor(self):
         color = Color(0.1, 0.3, 0.5, 0.7).with_r_factor(0.5)
-        self.assertEqual(color.get_rgba(), (0.05, 0.3, 0.5, 0.7))
+        self.assertEqual(color.rgba, (0.05, 0.3, 0.5, 0.7))
 
     def test_with_g_factor(self):
         color = Color(0.1, 0.3, 0.5, 0.7).with_g_factor(0.5)
-        self.assertEqual(color.get_rgba(), (0.1, 0.15, 0.5, 0.7))
+        self.assertEqual(color.rgba, (0.1, 0.15, 0.5, 0.7))
 
     def test_with_b_factor(self):
         color = Color(0.1, 0.3, 0.5, 0.7).with_b_factor(0.5)
-        self.assertEqual(color.get_rgba(), (0.1, 0.3, 0.25, 0.7))
+        self.assertEqual(color.rgba, (0.1, 0.3, 0.25, 0.7))
 
     def test_with_a_factor(self):
         color = Color(0.1, 0.3, 0.5, 0.7).with_a_factor(0.5)
-        self.assertEqual(color.get_rgba(), (0.1, 0.3, 0.5, 0.35))
+        self.assertEqual(color.rgba, (0.1, 0.3, 0.5, 0.35))
 
     def test_with_h_factor(self):
         color = Color(0.1, 0.3, 0.5, 0.7).with_h_factor(0.5)
-        self.assertAlmostEqual(color.get_rgba()[0], 0.2)
-        self.assertAlmostEqual(color.get_rgba()[1], 0.5)
-        self.assertAlmostEqual(color.get_rgba()[2], 0.1)
-        self.assertAlmostEqual(color.get_rgba()[3], 0.7)
+        self.assertAlmostEqual(color.rgba[0], 0.2)
+        self.assertAlmostEqual(color.rgba[1], 0.5)
+        self.assertAlmostEqual(color.rgba[2], 0.1)
+        self.assertAlmostEqual(color.rgba[3], 0.7)
 
     def test_with_s_factor(self):
         color = Color(0.1, 0.3, 0.5, 0.7).with_s_factor(0.5)
-        self.assertAlmostEqual(color.get_rgba()[0], 0.2)
-        self.assertAlmostEqual(color.get_rgba()[1], 0.3)
-        self.assertAlmostEqual(color.get_rgba()[2], 0.4)
-        self.assertAlmostEqual(color.get_rgba()[3], 0.7)
+        self.assertAlmostEqual(color.rgba[0], 0.2)
+        self.assertAlmostEqual(color.rgba[1], 0.3)
+        self.assertAlmostEqual(color.rgba[2], 0.4)
+        self.assertAlmostEqual(color.rgba[3], 0.7)
 
     def test_with_l_factor(self):
         color = Color(0.1, 0.3, 0.5, 0.7).with_l_factor(0.5)
-        self.assertAlmostEqual(color.get_rgba()[0], 0.05)
-        self.assertAlmostEqual(color.get_rgba()[1], 0.15)
-        self.assertAlmostEqual(color.get_rgba()[2], 0.25)
-        self.assertAlmostEqual(color.get_rgba()[3], 0.7)
+        self.assertAlmostEqual(color.rgba[0], 0.05)
+        self.assertAlmostEqual(color.rgba[1], 0.15)
+        self.assertAlmostEqual(color.rgba[2], 0.25)
+        self.assertAlmostEqual(color.rgba[3], 0.7)
 
     # Test lerp function
     def test_lerp_0(self):
         color = (Color(0.1, 0.2, 0.3, 0.4).lerp(Color(0.6, 0.7, 0.8, 0.9), 0))
-        self.assertEqual(color.get_rgba(), (0.1, 0.2, 0.3, 0.4))
+        self.assertEqual(color.rgba, (0.1, 0.2, 0.3, 0.4))
 
     def test_lerp_1(self):
         color = (Color(0.1, 0.2, 0.3, 0.4).lerp(Color(0.6, 0.7, 0.8, 0.9), 1))
-        self.assertEqual(color.get_rgba(), (0.6, 0.7, 0.8, 0.9))
+        self.assertEqual(color.rgba, (0.6, 0.7, 0.8, 0.9))
 
     def test_lerp_0_6(self):
         color = (Color(0.1, 0.2, 0.3, 0.4).lerp(Color(0.6, 0.7, 0.8, 0.9), 0.6))
-        self.assertAlmostEqual(color.get_rgba()[0], 0.4)
-        self.assertAlmostEqual(color.get_rgba()[1], 0.5)
-        self.assertAlmostEqual(color.get_rgba()[2], 0.6)
-        self.assertAlmostEqual(color.get_rgba()[3], 0.7)
+        self.assertAlmostEqual(color.rgba[0], 0.4)
+        self.assertAlmostEqual(color.rgba[1], 0.5)
+        self.assertAlmostEqual(color.rgba[2], 0.6)
+        self.assertAlmostEqual(color.rgba[3], 0.7)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
It looks nicer when are color object refers to properties rather than methods, i.e. `Color().rgb` instead of `Color().get_rgb()`