### PR TITLE
fix: add initial dependencies

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,3 @@
+[options]
+install_requires =
+    pycairo >= 1.20.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,4 @@
 [options]
 install_requires =
+    numpy >= 1.21.2
     pycairo >= 1.20.1


### PR DESCRIPTION
## Scope

This pull request adds the following dependencies to `setup.cfg`:

- `numpy >= 1.21.2`
- `pycairo >= 1.20.1`

This closes #2 

## Demonstration

Dependencies are now installed via `python setup.py install`:

```
(.env) 
Lewis@DESKTOP-IAO55HG MINGW64 ~/Documents/GitHub/generativepy (master)
$ python setup.py install
running install
...
Installed s:\users\lewis\documents\github\generativepy\.env\lib\site-packages\generativepy-2.5-py3.9.egg
Processing dependencies for generativepy==2.5
Searching for pycairo>=1.20.1
Reading https://pypi.org/simple/pycairo/
Downloading 
...
Searching for numpy>=1.21.2
Reading https://pypi.org/simple/numpy/
Downloading 
...
Finished processing dependencies for generativepy==2.5
```

This is evident via `pip freeze` after installation:

```
(.env)
Lewis@DESKTOP-IAO55HG MINGW64 ~/Documents/GitHub/generativepy (master)
$ pip freeze
generativepy==2.5
numpy==1.21.2
pycairo==1.20.1
```

The example scripts are now runnable:

```
(.env) 
Lewis@DESKTOP-IAO55HG MINGW64 ~/Documents/GitHub/generativepy (fix/add-initial-dependencies)    
$ python examples/geometry/circles.py
```

![image](https://user-images.githubusercontent.com/41923457/132723418-1ab199d4-cf94-43c8-b512-f10351527ffd.png)
